### PR TITLE
CMake link fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,5 +9,5 @@ find_library(config++ config++)
 find_library(fmt fmt)
 
 add_executable(tgrec main.cpp telegram_recorder.cpp auth.cpp message_reader.cpp config.cpp db.cpp telegram_data.cpp hash.cpp)
-target_link_libraries(tgrec PRIVATE Td::TdStatic config++ spdlog::spdlog fmt ssl)
+target_link_libraries(tgrec PRIVATE Td::TdStatic config++ spdlog::spdlog fmt ssl stdc++fs)
 set_property(TARGET tgrec PROPERTY CXX_STANDARD 17)


### PR DESCRIPTION
Below g++ 9.1, we need "stdc++fs" link for filesystem lib